### PR TITLE
Add support ansible-core >=2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 7.17.1 - 2024-01-12
+### What's Changed
+**Full Changelog**: https://github.com/obervinov/ansible-elasticsearch/compare/...7.17.1 by @obervinov
+#### 🐛 Bug Fixes
+* add support `ansible-core >=2.16`
+#### 💥 Breaking Changes
+* replace all deprecated functions `ansible.builtin.include` -> `ansible.builtin.import_tasks`
+
+
 ## 7.17.0
 
 * 7.17.0 as default version.

--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -65,7 +65,7 @@
 
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
-  include: elasticsearch-optional-user.yml
+  ansible.builtin.import_tasks: elasticsearch-optional-user.yml
 
 - name: Debian - Get installed elasticsearch version
   command: dpkg-query --showformat='${Version}' --show {{ es_package_name }}

--- a/tasks/elasticsearch-RedHat.yml
+++ b/tasks/elasticsearch-RedHat.yml
@@ -26,7 +26,7 @@
   when: es_use_repository
 
 - name: RedHat - include versionlock
-  include: elasticsearch-RedHat-version-lock.yml
+  ansible.builtin.import_tasks: elasticsearch-RedHat-version-lock.yml
 
 - name: RedHat - Remove the other elasticsearch package if switching between OSS and standard
   become: yes
@@ -36,7 +36,7 @@
 
 - name: Include optional user and group creation.
   when: (es_user_id is defined) and (es_group_id is defined)
-  include: elasticsearch-optional-user.yml
+  ansible.builtin.import_tasks: elasticsearch-optional-user.yml
 
 - name: RedHat - Install Elasticsearch
   become: yes

--- a/tasks/elasticsearch.yml
+++ b/tasks/elasticsearch.yml
@@ -1,9 +1,9 @@
 ---
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-Debian.yml
+  ansible.builtin.import_tasks: elasticsearch-Debian.yml
   when: ansible_os_family == 'Debian'
 
 - name: Include specific Elasticsearch
-  include: elasticsearch-RedHat.yml
+  ansible.builtin.import_tasks: elasticsearch-RedHat.yml
   when: ansible_os_family == 'RedHat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,49 +12,49 @@
       - always
 
 - name: set compatibility variables
-  include: compatibility-variables.yml
+  ansible.builtin.import_tasks: compatibility-variables.yml
   tags:
       - always
 
 - name: check-set-parameters
-  include: elasticsearch-parameters.yml
+  ansible.builtin.import_tasks: elasticsearch-parameters.yml
   tags:
       - always
 
 - name: use snapshot release
-  include: snapshot-release.yml
+  ansible.builtin.import_tasks: snapshot-release.yml
   when: es_use_snapshot_release
 
 - name: include java.yml
-  include: java.yml
+  ansible.builtin.import_tasks: java.yml
   when: es_java_install
   tags:
       - java
 
 - name: include elasticsearch.yml
-  include: elasticsearch.yml
+  ansible.builtin.import_tasks: elasticsearch.yml
   tags:
       - install
 
 - name: include elasticsearch-config.yml
-  include: elasticsearch-config.yml
+  ansible.builtin.import_tasks: elasticsearch-config.yml
   tags:
       - config
 
 - name: include elasticsearch-plugins.yml
-  include: elasticsearch-plugins.yml
+  ansible.builtin.import_tasks: elasticsearch-plugins.yml
   when: es_plugins is defined or es_plugins_reinstall
   tags:
       - plugins
 
   #We always execute xpack as we may need to remove features
 - name: include xpack/elasticsearch-xpack.yml
-  include: xpack/elasticsearch-xpack.yml
+  ansible.builtin.import_tasks: xpack/elasticsearch-xpack.yml
   tags:
       - xpack
 
 - name: include elasticsearch-ssl.yml
-  include: elasticsearch-ssl.yml
+  ansible.builtin.import_tasks: elasticsearch-ssl.yml
   when: es_enable_http_ssl or es_enable_transport_ssl
   tags:
       - xpack
@@ -88,25 +88,25 @@
   when: manage_native_realm | bool
 
 - name: activate-license
-  include: ./xpack/security/elasticsearch-xpack-activation.yml
+  ansible.builtin.import_tasks: ./xpack/security/elasticsearch-xpack-activation.yml
   when: es_start_service and not oss_version and es_xpack_license is defined and es_xpack_license != ''
   run_once: True
 
 - name: activate-trial
-  include: ./xpack/security/elasticsearch-xpack-trial-activation.yml
+  ansible.builtin.import_tasks: ./xpack/security/elasticsearch-xpack-trial-activation.yml
   when: es_start_service and not oss_version and es_xpack_trial
   run_once: True
 
 #perform security actions here now elasticsearch is started
 - name: include xpack/security/elasticsearch-security-native.yml
-  include: ./xpack/security/elasticsearch-security-native.yml
+  ansible.builtin.import_tasks: ./xpack/security/elasticsearch-security-native.yml
   when: manage_native_realm | bool
   run_once: True
 
 #Templates done after restart - handled by flushing the handlers. e.g. suppose user removes security on a running node and doesn't specify es_api_basic_auth_username and es_api_basic_auth_password.  The templates will subsequently not be removed if we don't wait for the node to restart.
 #We also do after the native realm to ensure any changes are applied here first and its denf up.
 - name: include elasticsearch-template.yml
-  include: elasticsearch-template.yml
+  ansible.builtin.import_tasks: elasticsearch-template.yml
   when: es_templates | bool
   tags:
       - templates

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -2,7 +2,7 @@
 
 #Security configuration
 - name: include security/elasticsearch-security.yml
-  include: security/elasticsearch-security.yml
+  ansible.builtin.import_tasks: security/elasticsearch-security.yml
   when: not oss_version
 
 #Make sure elasticsearch.keystore has correct Permissions

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -73,7 +73,7 @@
 
 #-----------------------------FILE BASED REALM----------------------------------------
 
-- include: elasticsearch-security-file.yml
+- ansible.builtin.import_tasks: elasticsearch-security-file.yml
   when: (es_users is defined and es_users.file is defined) or (es_roles is defined and es_roles.file is defined)
 
 #-----------------------------ROLE MAPPING ----------------------------------------


### PR DESCRIPTION
## 7.17.1 - 2024-01-12
### What's Changed
**Full Changelog**: https://github.com/obervinov/ansible-elasticsearch/compare/...7.17.1 by @obervinov
#### 🐛 Bug Fixes
* add support `ansible-core >=2.16`
#### 💥 Breaking Changes
* replace all deprecated functions `ansible.builtin.include` -> `ansible.builtin.import_tasks`